### PR TITLE
feature: add @blueprintjs/icons to registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
     },
     "cli": {
       "name": "@sly-cli/sly",
-      "version": "1.4.8",
+      "version": "1.4.10",
       "license": "MIT",
       "dependencies": {
         "cachified": "^3.5.4",
@@ -4099,6 +4099,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "license": "MIT",
@@ -4995,6 +5003,11 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -5582,6 +5595,33 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "license": "BSD-2-Clause",
@@ -5601,6 +5641,36 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -5995,6 +6065,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.3.1",
       "license": "BSD-2-Clause",
@@ -6097,6 +6218,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -9543,6 +9675,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "license": "MIT"
@@ -10458,6 +10595,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {
@@ -12503,6 +12651,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svgo": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.2.1",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.8.5",
       "dev": true,
@@ -13843,6 +14022,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "remix-flat-routes": "^0.5.10",
+        "svgo": "^3.0.2",
         "tailwindcss": "^3.3.3",
         "zod": "^3.21.4"
       },

--- a/site/app/routes/registry+/@blueprintjs.icons.$name[.json].ts
+++ b/site/app/routes/registry+/@blueprintjs.icons.$name[.json].ts
@@ -1,5 +1,5 @@
-// http://localhost:3000/registry/@radix-ui/icons/accessibility.json
-// https://sly-cli.fly.dev/registry/@radix-ui/icons/accessibility.json
+// http://localhost:3000/registry/@blueprintjs/icons/add.json
+// https://sly-cli.fly.dev/registry/@blueprintjs/icons/add.json
 
 import { json, type LoaderArgs } from "@remix-run/node"
 
@@ -8,8 +8,6 @@ import { type libraryItemWithContentSchema } from "../../schemas.js"
 import type { z } from "zod"
 import { optimize } from "svgo";
 import { getGithubFile } from "../../github.server.js"
-
-
 
 export async function loader({ params }: LoaderArgs) {
   const file = await getGithubFile({

--- a/site/app/routes/registry+/@blueprintjs.icons.$name[.json].ts
+++ b/site/app/routes/registry+/@blueprintjs.icons.$name[.json].ts
@@ -39,8 +39,20 @@ export async function loader({ params }: LoaderArgs) {
         content: [
           `<!-- ${meta.name} -->`,
           `<!-- ${meta.license} -->`,
-          await fetch(file.download_url).then((res) => res.text()).then(svg => optimize(svg).data),
-        ].join("\n"),
+          await fetch(file.download_url).then((res) => res.text())
+            .then(svg => optimize(svg, {
+              plugins: [
+                'preset-default',
+                "removeUselessStrokeAndFill",
+                {
+                  name: 'removeAttrs',
+                  params: {
+                    attrs: 'fill'
+                  }
+                }
+              ],
+            }).data),
+          ].join("\n"),
       },
     ],
   })

--- a/site/app/routes/registry+/@blueprintjs.icons.$name[.json].ts
+++ b/site/app/routes/registry+/@blueprintjs.icons.$name[.json].ts
@@ -1,0 +1,47 @@
+// http://localhost:3000/registry/@radix-ui/icons/accessibility.json
+// https://sly-cli.fly.dev/registry/@radix-ui/icons/accessibility.json
+
+import { json, type LoaderArgs } from "@remix-run/node"
+
+import { meta } from "./@blueprintjs.icons[.json].js"
+import { type libraryItemWithContentSchema } from "../../schemas.js"
+import type { z } from "zod"
+import { optimize } from "svgo";
+import { getGithubFile } from "../../github.server.js"
+
+
+
+export async function loader({ params }: LoaderArgs) {
+  const file = await getGithubFile({
+    owner: "palantir",
+    repo: "blueprint",
+    path: `resources/icons/16px/${params.name}.svg`,
+    ref: "develop",
+  })
+
+  if (!file) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  if (!file.download_url) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  return json<z.input<typeof libraryItemWithContentSchema>>({
+    name: file.name.replace(/\.svg$/, ""),
+    meta: {
+      ...meta,
+      source: file.html_url ?? meta.source,
+    },
+    files: [
+      {
+        name: file.name,
+        content: [
+          `<!-- ${meta.name} -->`,
+          `<!-- ${meta.license} -->`,
+          await fetch(file.download_url).then((res) => res.text()).then(svg => optimize(svg).data),
+        ].join("\n"),
+      },
+    ],
+  })
+}

--- a/site/app/routes/registry+/@blueprintjs.icons[.json].ts
+++ b/site/app/routes/registry+/@blueprintjs.icons[.json].ts
@@ -1,0 +1,47 @@
+// http://localhost:3000/registry/@blueprintjs/icons.json
+// https://sly-cli.fly.dev/registry/@blueprintjs/icons.json
+
+import { json, type LoaderArgs } from "@remix-run/node"
+import type { z } from "zod"
+import { type libraryIndexSchema } from "../../schemas.js"
+import { getGithubDirectory } from "../../github.server.js"
+
+export const meta = {
+  name: "@blueprintjs/icons",
+  source:
+    "https://github.com/blueprintjs/icons/tree/master/packages/radix-icons/icons",
+  description: "Blueprint is a React UI toolkit for the web.",
+  license: "https://github.com/palantir/blueprint/blob/develop/LICENSE",
+} as const
+
+export async function loader({ request }: LoaderArgs) {
+  // TODO: include 20px icons?
+  const files = await getGithubDirectory({
+    owner: "palantir",
+    repo: "blueprint",
+    path: "resources/icons/16px",
+    ref: "develop",
+  })
+
+  const resources = files
+    .filter((file) => {
+      if (!file.path?.endsWith(".svg")) return false
+
+      return true
+    })
+    .map((file) => {
+      if (!file.path) throw new Error("File path is undefined")
+
+      return {
+        name: file.path
+          ?.replace(/^resources\/icons\/16px\//, "")
+          .replace(/\.svg$/, ""),
+      }
+    })
+
+  return json<z.input<typeof libraryIndexSchema>>({
+    version: "1.0.0",
+    meta,
+    resources,
+  })
+}

--- a/site/app/routes/registry+/@blueprintjs.icons[.json].ts
+++ b/site/app/routes/registry+/@blueprintjs.icons[.json].ts
@@ -9,7 +9,7 @@ import { getGithubDirectory } from "../../github.server.js"
 export const meta = {
   name: "@blueprintjs/icons",
   source:
-    "https://github.com/blueprintjs/icons/tree/master/packages/radix-icons/icons",
+    "https://github.com/palantir/blueprint/tree/develop/resources/icons/16px",
   description: "Blueprint is a React UI toolkit for the web.",
   license: "https://github.com/palantir/blueprint/blob/develop/LICENSE",
 } as const

--- a/site/app/routes/registry+/index[.json].ts
+++ b/site/app/routes/registry+/index[.json].ts
@@ -9,6 +9,8 @@ import { meta as lucideMeta } from "./lucide-icons[.json].js"
 import { meta as transformersMeta } from "./@sly-cli.transformers[.json].js"
 import { meta as simpleIconsMeta } from "./simple-icons[.json].js"
 import { meta as heroiconsMeta } from "./tailwindlabs.heroicons[.json].js"
+import { meta as blueprintIconsMeta } from "./@blueprintjs.icons[.json].js"
+
 import type { registryIndexSchema } from "../../schemas.js"
 import cachified from "cachified"
 import { cache } from "../../cache.server.js"
@@ -35,6 +37,7 @@ export async function loader({ request }: LoaderArgs) {
   return json<z.input<typeof registryIndexSchema>>({
     version: npm["dist-tags"].latest,
     libraries: [
+      blueprintIconsMeta,
       heroiconsMeta,
       lucideMeta,
       radixMeta,

--- a/site/package.json
+++ b/site/package.json
@@ -20,6 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remix-flat-routes": "^0.5.10",
+    "svgo": "^3.0.2",
     "tailwindcss": "^3.3.3",
     "zod": "^3.21.4"
   },


### PR DESCRIPTION
This PR adds support for @blueprintjs/icons to resolve #1 

It also adds `svgo` which dynamically reduces svg size immensely for blueprint icons. I understand you may not want to add more dependencies, but this makes a huge difference.

before svgo:
```
'<!-- @blueprintjs/icons -->\n<!-- https://github.com/palantir/blueprint/blob/develop/LICENSE -->\n<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">\n<path fill-rule="evenodd" clip-rule="evenodd" d="M12 0C11.4477 0 11 0.447715 11 1V3H9C8.44772 3 8 3.44772 8 4C8 4.55228 8.44771 5 9 5H11V7C11 7.55228 11.4477 8 12 8C12.5523 8 13 7.55228 13 7V5H15C15.5523 5 16 4.55228 16 4C16 3.44772 15.5523 3 15 3H13V1C13 0.447715 12.5523 0 12 0ZM0 4C0 3.44772 0.447715 3 1 3H4.5C5.05228 3 5.5 3.44772 5.5 4C5.5 4.55228 5.05228 5 4.5 5H2V7C2 7.55228 1.55228 8 1 8C0.447715 8 0 7.55228 0 7V4ZM1 16C0.447715 16 0 15.5523 0 15V12C0 11.4477 0.447715 11 1 11C1.55228 11 2 11.4477 2 12V14H4.5C5.05228 14 5.5 14.4477 5.5 15C5.5 15.5523 5.05228 16 4.5 16H1ZM12 16C12.2652 16 12.5196 15.8946 12.7071 15.7071C12.8946 15.5196 13 15.2652 13 15V12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V14L9 14C8.44772 14 8 14.4477 8 15C8 15.5523 8.44771 16 9 16L12 16ZM6.5 12C7.88071 12 9 10.8807 9 9.5C9 8.11929 7.88071 7 6.5 7C5.11929 7 4 8.11929 4 9.5C4 10.8807 5.11929 12 6.5 12Z" />\n</svg>\n'
--


```

after svgo:
```
'<!-- @blueprintjs/icons -->\n<!-- https://github.com/palantir/blueprint/blob/develop/LICENSE -->\n<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill-rule="evenodd" d="M12 0a1 1 0 0 0-1 1v2H9a1 1 0 0 0 0 2h2v2a1 1 0 1 0 2 0V5h2a1 1 0 1 0 0-2h-2V1a1 1 0 0 0-1-1ZM0 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 0 2H2v2a1 1 0 0 1-2 0V4Zm1 12a1 1 0 0 1-1-1v-3a1 1 0 1 1 2 0v2h2.5a1 1 0 1 1 0 2H1Zm11 0a1 1 0 0 0 1-1v-3a1 1 0 1 0-2 0v2H9a1 1 0 1 0 0 2h3Zm-5.5-4a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" clip-rule="evenodd"/></svg>'
```

Hope this PR helps!
