### PR TITLE
Fix iconoir paths after icon directory split

### DIFF
--- a/site/app/routes/registry+/iconoir.$type.$name[.json].ts
+++ b/site/app/routes/registry+/iconoir.$type.$name[.json].ts
@@ -11,7 +11,7 @@ export async function loader({ params }: LoaderArgs) {
   const icon = await getGithubFile({
     owner: "iconoir-icons",
     repo: "iconoir",
-    path: `icons/${params.name}.svg`,
+    path: `icons/${params.type}/${params.name}.svg`,
     ref: "main",
   })
 


### PR DESCRIPTION
Since Iconoir team decided to [split icon directories](https://github.com/iconoir-icons/iconoir/tree/main/icons) in a [recent change](https://github.com/iconoir-icons/iconoir/commit/d73b7282ddd57caec341a6990c8456b911186e9b), installing Iconoir icons is currently failing. This PR addresses that. 