### PR TITLE
feat: add material-design-icons to registry

### DIFF
--- a/site/app/routes/_index.tsx
+++ b/site/app/routes/_index.tsx
@@ -46,6 +46,10 @@ const registries = [
     href: "https://tabler-icons.io/",
     name: "tabler-icons",
   },
+  {
+    href: "https://marella.me/material-design-icons/demo/svg/",
+    name: "material-design-icons",
+  },
 ]
 
 export default function Index() {

--- a/site/app/routes/registry+/index[.json].ts
+++ b/site/app/routes/registry+/index[.json].ts
@@ -12,6 +12,7 @@ import { meta as simpleIconsMeta } from "./simple-icons[.json].js"
 import { meta as heroiconsMeta } from "./tailwindlabs.heroicons[.json].js"
 import { meta as blueprintIconsMeta } from "./@blueprintjs.icons[.json].js"
 import { meta as tablerIconsMeta } from "./tabler-icons[.json].js";
+import { meta as materialDesignIconsMeta } from "./material-design-icons[.json].js"
 
 import type { registryIndexSchema } from "../../schemas.js"
 import cachified from "cachified"
@@ -47,6 +48,7 @@ export async function loader({ request }: LoaderArgs) {
       simpleIconsMeta,
       shadcnMeta,
       tablerIconsMeta,
+      materialDesignIconsMeta,
       transformersMeta,
     ],
   })

--- a/site/app/routes/registry+/material-design-icons.$name[.json].ts
+++ b/site/app/routes/registry+/material-design-icons.$name[.json].ts
@@ -1,0 +1,66 @@
+// http://localhost:3000/registry/material-design-icons/mobile_friendly-filled.json
+// https://sly-cli.fly.dev/registry/material-design-icons/mobile_friendly-filled.json
+
+import { json, type LoaderArgs } from "@remix-run/node"
+import { meta } from "./material-design-icons[.json].js"
+import { type libraryItemWithContentSchema } from "../../schemas.js"
+import type { z } from "zod"
+import { getGithubFile } from "../../github.server.js"
+
+export async function loader({ params }: LoaderArgs) {
+  if (!params.name) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  const dir = params.name.endsWith("-filled")
+    ? "filled"
+    : params.name.endsWith("-outlined")
+    ? "outlined"
+    : params.name.endsWith("-round")
+    ? "round"
+    : params.name.endsWith("-sharp")
+    ? "sharp"
+    : params.name.endsWith("-two-tone")
+    ? "two-tone"
+    : ""
+
+  const trimmedName = params.name
+    .replace(/-filled$/, "")
+    .replace(/-outlined$/, "")
+    .replace(/-round$/, "")
+    .replace(/-sharp$/, "")
+    .replace(/-two-tone$/, "")
+
+  const icon = await getGithubFile({
+    owner: "marella",
+    repo: "material-design-icons",
+    path: `svg/${dir}/${trimmedName}.svg`,
+    ref: "main",
+  })
+
+  if (!icon) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  if (!icon.download_url) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  return json<z.input<typeof libraryItemWithContentSchema>>({
+    name: icon.name.replace(/\.svg$/, `-${dir}`),
+    meta: {
+      ...meta,
+      source: icon.html_url ?? meta.source,
+    },
+    files: [
+      {
+        name: icon.name.replace(/\.svg$/, `-${dir}.svg`),
+        content: [
+          `<!-- ${meta.name} -->`,
+          `<!-- ${meta.license} -->`,
+          await fetch(icon.download_url).then((res) => res.text()),
+        ].join("\n"),
+      },
+    ],
+  })
+}

--- a/site/app/routes/registry+/material-design-icons[.json].ts
+++ b/site/app/routes/registry+/material-design-icons[.json].ts
@@ -1,0 +1,93 @@
+// http://localhost:3000/registry/material-design-icons.json
+// https://sly-cli.fly.dev/registry/material-design-icons.json
+
+import { json, type LoaderArgs } from "@remix-run/node"
+import type { z } from "zod"
+import { type libraryIndexSchema } from "../../schemas.js"
+import { getGithubDirectory } from "../../github.server.js"
+
+export const meta = {
+  name: "material-design-icons",
+  source: "https://github.com/marella/material-design-icons/tree/main/svg",
+  description: "Material Design icons by Google",
+  license:
+    "https://github.com/google/material-design-icons/blob/master/LICENSE",
+} as const
+
+export async function loader({ request }: LoaderArgs) {
+  const allFiles = await getGithubDirectory({
+    owner: "marella",
+    repo: "material-design-icons",
+    path: "svg",
+    ref: "main",
+  })
+
+  const allSvgFiles = allFiles.filter((file) => {
+    if (!file.path) throw new Error("File path is undefined")
+    return Boolean(file.path.endsWith(".svg"))
+  })
+
+  const filledResources = allSvgFiles
+    .filter((file) => file.path.startsWith("svg/filled/"))
+    .map((file) => {
+      return {
+        name: file.path
+          .replace(/^svg\/filled\//, "")
+          .replace(/\.svg$/, "-filled"),
+      }
+    })
+
+  const outlinedResources = allSvgFiles
+    .filter((file) => file.path.startsWith("svg/outlined/"))
+    .map((file) => {
+      return {
+        name: file.path
+          .replace(/^svg\/outlined\//, "")
+          .replace(/\.svg$/, "-outlined"),
+      }
+    })
+
+  const roundResources = allSvgFiles
+    .filter((file) => file.path.startsWith("svg/round/"))
+    .map((file) => {
+      return {
+        name: file.path
+          .replace(/^svg\/round\//, "")
+          .replace(/\.svg$/, "-round"),
+      }
+    })
+
+  const sharpResources = allSvgFiles
+    .filter((file) => file.path.startsWith("svg/sharp/"))
+    .map((file) => {
+      return {
+        name: file.path
+          .replace(/^svg\/sharp\//, "")
+          .replace(/\.svg$/, "-sharp"),
+      }
+    })
+
+  const twoToneResources = allSvgFiles
+    .filter((file) => file.path.startsWith("svg/two-tone/"))
+    .map((file) => {
+      return {
+        name: file.path
+          .replace(/^svg\/two-tone\//, "")
+          .replace(/\.svg$/, "-two-tone"),
+      }
+    })
+
+  const resources = [
+    ...filledResources,
+    ...outlinedResources,
+    ...roundResources,
+    ...sharpResources,
+    ...twoToneResources,
+  ].sort((a, b) => a.name.localeCompare(b.name))
+
+  return json<z.input<typeof libraryIndexSchema>>({
+    version: "1.0.0",
+    meta,
+    resources,
+  })
+}


### PR DESCRIPTION
@jacobparis Material Design Icons have five different variants (`filled`, `outlined`, `round`, `sharp`, and `two-tone`). I considered adding each one to the registry individually for easier consumption (e.g., developers will find the icon names like `mobile_friendly` and if these were separate registry entries, they could use Sly to add that name exactly as opposed to `mobile_friendly-filled`), but I followed suit in regards to how you handled the two variants in `heroicons`. Open to changing it, though.

Also, it may be worth noting that the source for these icons is technically a third-party repository. The reason for this is that the official Google repository is too large for the `rest.git.getTree` Octokit API used in `github.server.ts` as it contains all related assets for multiple platforms (not just SVGs). I looked into alternative ways to get this much data, but everything I found required a GitHub API token and would still run into rate limiting without some throttling. Luckily, some kind soul has broken out the various files into individual repositories (e.g., https://github.com/marella/material-design-icons) that automatically update whenever Google updates the source repository. **Google links to these from their official repository** (https://github.com/google/material-design-icons#npm-packages), so I feel fairly confident using them over some other solution.