### PR TITLE
feat: add draft-ui to registry

### DIFF
--- a/site/app/routes/registry+/draft-ui.$name[.json].ts
+++ b/site/app/routes/registry+/draft-ui.$name[.json].ts
@@ -1,0 +1,44 @@
+// http://localhost:3000/registry/draft-ui/breadcrumbs.json
+// https://sly-cli.fly.dev/registry/draft-ui/breadcrumbs.json
+
+import { json, type LoaderFunctionArgs } from "@remix-run/node"
+
+import { meta } from "./draft-ui[.json]"
+import { type libraryItemWithContentSchema } from "../../schemas.js"
+import type { z } from "zod"
+import { getGithubFile } from "../../github.server.js"
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const file = await getGithubFile({
+    owner: "IHIutch",
+    repo: "draft-ui",
+    path: `packages/ui/src/${params.name}.tsx`,
+    ref: "main",
+  });
+
+  if (!file) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  if (!file.download_url) {
+    throw new Response("Not found", { status: 404 })
+  }
+
+  return json<z.input<typeof libraryItemWithContentSchema>>({
+    name: file.name,
+    meta: {
+      ...meta,
+      source: file.html_url ?? meta.source,
+    },
+    files: [
+      {
+        name: file.name,
+        content: [
+          `// ${meta.name}`,
+          `// ${meta.license}`,
+          await fetch(file.download_url).then((res) => res.text()),
+        ].join("\n"),
+      },
+    ],
+  })
+}

--- a/site/app/routes/registry+/draft-ui[.json].ts
+++ b/site/app/routes/registry+/draft-ui[.json].ts
@@ -1,0 +1,46 @@
+// http://localhost:3000/registry/draft-ui.json
+// https://sly-cli.fly.dev/registry/draft-ui.json
+
+import { json, type LoaderFunctionArgs } from "@remix-run/node"
+import type { z } from "zod"
+import { type libraryIndexSchema } from "../../schemas.js"
+import { getGithubDirectory } from "../../github.server.js"
+
+export const meta = {
+  name: "draft-ui",
+  source: "https://github.com/IHIutch/draft-ui",
+  description:
+    "Draft UI is a collection of simply designed React components focused on making web accessibility as easy as copy & paste.",
+  license: "https://github.com/IHIutch/draft-ui",
+} as const
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const files = await getGithubDirectory({
+    owner: "IHIutch",
+    repo: "draft-ui",
+    path: "packages/ui/src",
+    ref: "main",
+  })
+
+  const resources = files
+    .filter((file) => {
+      if (!file.path?.endsWith(".tsx")) return false
+
+      return true
+    })
+    .map((file) => {
+      if (!file.path) throw new Error("File path is undefined")
+
+      return {
+        name: file.path
+          ?.replace(/^packages\/ui\/src\//, "")
+          .replace(/\.tsx$/, ""),
+      }
+    })
+
+  return json<z.input<typeof libraryIndexSchema>>({
+    version: "1.0.0",
+    meta,
+    resources,
+  })
+}

--- a/site/app/routes/registry+/index[.json].ts
+++ b/site/app/routes/registry+/index[.json].ts
@@ -13,6 +13,7 @@ import { meta as heroiconsMeta } from "./tailwindlabs.heroicons[.json].js"
 import { meta as blueprintIconsMeta } from "./@blueprintjs.icons[.json].js"
 import { meta as tablerIconsMeta } from "./tabler-icons[.json].js"
 import { meta as materialDesignIconsMeta } from "./material-design-icons[.json].js"
+import { meta as draftUiMeta } from "./draft-ui[.json].js"
 
 import type { registryIndexSchema } from "../../schemas.js"
 import cachified from "cachified"
@@ -36,6 +37,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     version: npm["dist-tags"].latest,
     libraries: [
       blueprintIconsMeta,
+      draftUiMeta,
       heroiconsMeta,
       lucideMeta,
       iconoirMeta,


### PR DESCRIPTION
As per https://github.com/IHIutch/draft-ui/issues/5

Add Draft-UI to registry. 

I believe these are the only changes needed. DraftUI does not have a registry like shadcn, so using the github method.

Would want @IHIutch approval before approving