### PR TITLE
feat: add Jolly-UI

### DIFF
--- a/site/app/routes/registry+/index[.json].ts
+++ b/site/app/routes/registry+/index[.json].ts
@@ -4,6 +4,7 @@
 import { json, type LoaderFunctionArgs } from "@remix-run/node"
 import type { z } from "zod"
 import { meta as shadcnMeta } from "./@shadcn.ui[.json].js"
+import { meta as jollyUiMeta } from "./jolly-ui[.json].js"
 import { meta as iconoirMeta } from "./iconoir[.json].js"
 import { meta as radixMeta } from "./@radix-ui.icons[.json].js"
 import { meta as lucideMeta } from "./lucide-icons[.json].js"
@@ -41,6 +42,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       heroiconsMeta,
       lucideMeta,
       iconoirMeta,
+      jollyUiMeta,
       radixMeta,
       simpleIconsMeta,
       shadcnMeta,

--- a/site/app/routes/registry+/jolly-ui.$name[.json].ts
+++ b/site/app/routes/registry+/jolly-ui.$name[.json].ts
@@ -1,0 +1,48 @@
+// http://localhost:3000/registry/jolly-ui/avatar.json
+// https://sly-cli.fly.dev/registry/jolly-ui/avatar.json
+
+import { json, type LoaderFunctionArgs } from "@remix-run/node"
+import { meta } from "./jolly-ui[.json].js"
+import { z } from "zod"
+import type { libraryItemWithContentSchema } from "../../schemas.js"
+import { cache } from "../../cache.server.js"
+import cachified from "cachified"
+const jollyFile = z.object({
+  name: z.string(),
+  dependencies: z.array(z.string()).optional(),
+  registryDependencies: z.array(z.string()).optional(),
+  files: z
+    .array(z.object({ name: z.string(), content: z.string() }))
+    .default([]),
+  type: z.string(),
+})
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const component = await cachified({
+    key: `jolly-ui/registry/styles/default/${params.name}.json`,
+    cache: cache,
+    staleWhileRevalidate: 1000 * 60 * 60, // 1 hour
+    ttl: 1000 * 60 * 60, // 1 hour
+    checkValue: jollyFile,
+    async getFreshValue() {
+      console.log(`Cache miss for jolly-ui/${params.name}`)
+      return fetch(
+        `https://jollyui.dev/registry/styles/default/${params.name}.json`
+      ).then((res) => res.json())
+    },
+  })
+
+  return json<z.input<typeof libraryItemWithContentSchema>>({
+    name: component.name,
+    meta: {
+      ...meta,
+      source: `https://api.github.com/repos/shadcn-aria/apps/docs/registry/default/ui/${params.name}.tsx`,
+    },
+    dependencies: component.dependencies ?? [],
+    registryDependencies: component.registryDependencies ?? [],
+    files: component.files.map((file) => ({
+      name: file.name,
+      content: file.content,
+    })),
+  })
+}

--- a/site/app/routes/registry+/jolly-ui[.json].ts
+++ b/site/app/routes/registry+/jolly-ui[.json].ts
@@ -1,0 +1,50 @@
+// http://localhost:3000/registry/jolly-ui.json
+// https://sly-cli.fly.dev/registry/jolly-ui.json
+
+import { json, type LoaderFunctionArgs } from "@remix-run/node"
+import cachified from "cachified"
+import { z } from "zod"
+import { cache } from "~/cache.server"
+import type { libraryIndexSchema } from "~/schemas"
+
+export const jollyFile = z.object({
+  name: z.string(),
+  dependencies: z.array(z.string()).default([]),
+  registryDependencies: z.array(z.string()).default([]),
+  files: z.array(z.string()).default([]),
+  type: z.string(),
+})
+
+export const meta = {
+  name: "jolly-ui",
+  source: "https://github.com/jolbol1/shadcn-aria",
+  description:
+    "shadcn/ui compatible react aria components that you can copy and paste into your apps. Accessible. Customizable. Open Source.",
+  license: "https://github.com/jolbol1/shadcn-aria/blob/main/LICENSE.md",
+} as const
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const jolly = await cachified({
+    key: "jolly-ui/registry",
+    cache: cache,
+    staleWhileRevalidate: 1000 * 60 * 60, // 1 hour
+    ttl: 1000 * 60 * 60, // 1 hour
+    checkValue: z.array(jollyFile),
+    async getFreshValue() {
+      console.log(`Cache miss for jolly-ui/registry`)
+      return fetch("https://jollyui.dev/registry").then((res) => res.json())
+    },
+  })
+
+  const icons = jolly.map((component) => ({
+    name: component.name,
+    dependencies: component.dependencies,
+    registryDependencies: component.registryDependencies,
+  }))
+
+  return json<z.input<typeof libraryIndexSchema>>({
+    version: "1.0.0",
+    meta,
+    resources: icons,
+  })
+}


### PR DESCRIPTION
Hey, Im the creator of https://www.jollyui.dev/ a shadcn/ui compatible library for react-aria-components, similar to draftUI.

This PR adds it.

Just wondering if there is a good way to handle the styles in this and shadcn, as they have the choice between default and new-york but I think sly assumes default?

Let me know if you are okay with this addition. Thanks!

Addresses https://github.com/jolbol1/shadcn-aria/issues/9