### PR TITLE
fix: update jolly-ui repo links for rename

### DIFF
--- a/site/app/routes/registry+/jolly-ui.$name[.json].ts
+++ b/site/app/routes/registry+/jolly-ui.$name[.json].ts
@@ -36,7 +36,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     name: component.name,
     meta: {
       ...meta,
-      source: `https://api.github.com/repos/shadcn-aria/apps/docs/registry/default/ui/${params.name}.tsx`,
+      source: `https://api.github.com/repos/jolly-ui/apps/docs/registry/default/ui/${params.name}.tsx`,
     },
     dependencies: component.dependencies ?? [],
     registryDependencies: component.registryDependencies ?? [],

--- a/site/app/routes/registry+/jolly-ui[.json].ts
+++ b/site/app/routes/registry+/jolly-ui[.json].ts
@@ -17,10 +17,10 @@ export const jollyFile = z.object({
 
 export const meta = {
   name: "jolly-ui",
-  source: "https://github.com/jolbol1/shadcn-aria",
+  source: "https://github.com/jolbol1/jolly-ui",
   description:
     "shadcn/ui compatible react aria components that you can copy and paste into your apps. Accessible. Customizable. Open Source.",
-  license: "https://github.com/jolbol1/shadcn-aria/blob/main/LICENSE.md",
+  license: "https://github.com/jolbol1/jolly-ui/blob/main/LICENSE.md",
 } as const
 
 export async function loader({ request }: LoaderFunctionArgs) {


### PR DESCRIPTION
I have updated the repo name for jolly-ui to reflect its rename. 

This adjusts the links to match. I dont think its a breaking issue as I believe this is just meta,  and github redirects anyways.

Thanks!