### PR TITLE
fix: throw errors while waiting in tests

### DIFF
--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
       showDiff: false,
       truncateThreshold: 1000,
     },
+    globalSetup: "../test/setup.ts",
   },
 })

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     // Site tests involve installing different CLIs from npm
     // so they need a longer timeout
-    testTimeout: 15000,
+    testTimeout: 30000,
     // run tests in sequence instead of parallel
     chaiConfig: {
       showDiff: false,
@@ -14,5 +14,6 @@ export default defineConfig({
     env: {
       REGISTRY_URL: "http://localhost:3000",
     },
+    globalSetup: "../test/setup.ts",
   },
 })

--- a/test/add.ts
+++ b/test/add.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process"
-import { test, afterAll, describe, vi } from "vitest"
+import { test, afterAll, describe } from "vitest"
 import { compareVersions } from "compare-versions"
 
 import { rmSync } from "fs"
@@ -114,7 +114,7 @@ export function sharedTests(context: {
 
         await waitForFinish()
 
-        // await cleanup()
+        await cleanup()
       }
     )
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,7 @@
+export default function setup() {
+  process.on("unhandledRejection", (reason) => {
+    // eslint-disable-next-line no-console
+    console.log(`FAILED TO HANDLE PROMISE REJECTION`)
+    throw reason
+  })
+}

--- a/test/spawnSly.ts
+++ b/test/spawnSly.ts
@@ -36,7 +36,7 @@ export async function spawnSly(
 
     let interval: NodeJS.Timer | number = 0
     const result = await Promise.race([
-      new Promise((_, reject) => setTimeout(reject, 5000)),
+      new Promise((_, reject) => setTimeout(reject, 15000)),
       new Promise((resolve) => {
         let lastRead = lastSuccessfulWaitForText
         interval = setInterval(() => {


### PR DESCRIPTION
Vitest would swallow any unhandled promise rejections that occurred during the test assertions, leading to false negative tests