### PR TITLE
feature: add healthcheck

### DIFF
--- a/cli/src/healthcheck.ts
+++ b/cli/src/healthcheck.ts
@@ -1,0 +1,35 @@
+import { logger } from "./logger.js"
+
+export async function healthcheck() {
+  const baseUrl = process.env.REGISTRY_URL || "https://sly-cli.fly.dev"
+
+  if (
+    baseUrl.endsWith("/") ||
+    baseUrl.endsWith(".json") ||
+    baseUrl.includes("registry")
+  ) {
+    logger.error(
+      `The registry URL should just be the basename with no trailing slash, like\n\nREGISTRY_URL=http://localhost:3000`
+    )
+    process.exit(1)
+  }
+
+  await fetch(`${baseUrl}/registry/index.json`, {
+    method: "HEAD",
+  }).catch(() => {
+    logger.error(
+      `Could not connect to the registry at ${baseUrl}/registry/index.json.`
+    )
+
+    if (process.env.REGISTRY_URL === "https://sly-cli.fly.dev") {
+      logger.info(
+        `If your internet connection is working, Sly may be experiencing an outage.`
+      )
+    } else {
+      logger.info(
+        "Check to see if the registry is running, or provide a custom URL by setting the REGISTRY_URL environment variable."
+      )
+    }
+    process.exit(1)
+  })
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,10 +8,12 @@ import { refresh } from "./commands/refresh.js"
 import { libraryCommand } from "./commands/library.js"
 import { checkVersion } from "./check-version.js"
 import packageJson from "../package.json"
+import { healthcheck } from "./healthcheck.js"
 
 process.on("SIGINT", () => process.exit(0))
 process.on("SIGTERM", () => process.exit(0))
 
+await healthcheck()
 await checkVersion()
 void restoreCache()
 


### PR DESCRIPTION
Throws a more descriptive error when the registry cannot be found. Most of the time this happens when dealing with a custom registry and having the path wrong. 