### PR TITLE
feature: update tabler icons to variants

### DIFF
--- a/site/app/routes/registry+/tabler-icons.$name[.json].ts
+++ b/site/app/routes/registry+/tabler-icons.$name[.json].ts
@@ -8,11 +8,16 @@ import type { z } from "zod"
 import { getGithubFile } from "../../github.server.js"
 
 export async function loader({ params }: LoaderFunctionArgs) {
+  const variant = params.name?.endsWith("-outline") ? "outline" : "filled"
+  const trimmedName = params.name
+    ?.replace(/-outline$/, "")
+    .replace(/-filled$/, "")
+
   const icon = await getGithubFile({
     owner: "tabler",
     repo: "tabler-icons",
-    path: `icons/${params.name}.svg`,
-    ref: "master",
+    path: `icons/${variant}/${trimmedName}.svg`,
+    ref: "main",
   })
 
   if (!icon) {
@@ -24,14 +29,14 @@ export async function loader({ params }: LoaderFunctionArgs) {
   }
 
   return json<z.input<typeof libraryItemWithContentSchema>>({
-    name: icon.name.replace(/\.svg$/, ""),
+    name: icon.name.replace(/\.svg$/, `-${variant}`),
     meta: {
       ...meta,
       source: icon.html_url ?? meta.source,
     },
     files: [
       {
-        name: icon.name,
+        name: icon.name.replace(/\.svg$/, `-${variant}.svg`),
         content: [
           `<!-- ${meta.name} -->`,
           `<!-- ${meta.license} -->`,

--- a/site/tests/list-versions.js
+++ b/site/tests/list-versions.js
@@ -1,5 +1,4 @@
 import fs from "fs"
-import fetch from "node-fetch"
 
 const versions = await fetchSupportedVersions()
 


### PR DESCRIPTION
Tabler Icons has switched their trunk branch from `master` to `main` (good) which breaks the library in our registry (bad). They've also added variants to the icons in a similar way to how Heroicons does, so I've used the same implementation here

Each icon now gets appended `heart-filled.svg` or `heart-outline.svg`

Fixes #48